### PR TITLE
feat!: v2 cleanup — rename input, drop deprecated internals, modernize provider

### DIFF
--- a/.tflint.hcl
+++ b/.tflint.hcl
@@ -12,18 +12,4 @@ plugin "aws" {
 
 rule "terraform_naming_convention" {
     enabled = true
-
-    # Allow hyphens in variable names to permit the existing
-    # `role_subject-repos_policies` variable without a breaking rename.
-    variable {
-        format = "none"
-        custom = "^[a-z][a-z0-9_-]*$"
-    }
-
-    # Keep snake_case defaults for everything else.
-    module       { format = "snake_case" }
-    locals       { format = "snake_case" }
-    output       { format = "snake_case" }
-    resource     { format = "snake_case" }
-    data         { format = "snake_case" }
 }

--- a/MIGRATING.md
+++ b/MIGRATING.md
@@ -1,0 +1,137 @@
+# Migrating from v0.x to v1.0.0
+
+v1.0.0 is the first breaking release of this module. The code changes are small and mechanical; the `terraform plan` against an existing v0.6.x deployment will show a few expected diffs, none of which replace resources.
+
+## TL;DR
+
+1. Rename the module input `role_subject-repos_policies` → `roles`.
+2. Replace references to the `iam_role_arns` output with `iam_role_arns_map["<role-name>"]`.
+3. Bump your AWS provider floor to `>= 5.39.0`.
+4. `terraform plan`, review, `terraform apply`.
+
+No resources are replaced. No live privilege gap on IAM role policy attachments.
+
+## Version floors
+
+| Component              | v0.x            | v1.0.0            |
+| ---------------------- | --------------- | ----------------- |
+| Terraform              | `>= 1.5.7`      | `>= 1.5.7`        |
+| `hashicorp/aws`        | `>= 4.0`        | `>= 5.39.0`       |
+| `hashicorp/tls`        | `>= 4.0.3` *    | (not required)    |
+
+\* The `tls` provider was already dropped in v0.6.0; it's listed here only if your own root module still declares it on our behalf.
+
+`aws >= 5.39.0` is required because v1.0.0 drops `thumbprint_list` from the OIDC provider resource, which the AWS provider made optional in [hashicorp/terraform-provider-aws#37278](https://github.com/hashicorp/terraform-provider-aws/pull/37278).
+
+## Step 1 — Rename `role_subject-repos_policies` → `roles`
+
+The object shape is unchanged, only the variable name differs.
+
+```diff
+ module "aws_oidc_github" {
+   source  = "pelotech/oidc-github/aws"
+-  version = "~> 0.6"
++  version = "~> 1.0"
+
+-  role_subject-repos_policies = {
++  roles = {
+     "deploy-main" = {
+       subject_repos = ["repo:my-org/my-repo:ref:refs/heads/main"]
+       policy_arns   = ["arn:aws:iam::aws:policy/AmazonS3ReadOnlyAccess"]
+     }
+   }
+ }
+```
+
+A single find/replace handles it:
+
+```sh
+grep -rl 'role_subject-repos_policies' . | xargs sed -i '' 's/role_subject-repos_policies/roles/g'
+```
+
+## Step 2 — Switch to the `iam_role_arns_map` output
+
+The flat `iam_role_arns` list (deprecated since v0.6.0) is removed. Use the map output keyed by role name:
+
+```diff
+ output "role_arn" {
+-  value = module.aws_oidc_github.iam_role_arns[0]
++  value = module.aws_oidc_github.iam_role_arns_map["deploy-main"]
+ }
+```
+
+## Step 3 — Bump your AWS provider floor
+
+In any root module that pins the AWS provider, make sure the floor is at least `5.39.0`:
+
+```hcl
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 5.39.0"
+    }
+  }
+}
+```
+
+## What `terraform plan` will show
+
+Against an existing v0.6.x deployment, expect three kinds of in-place changes. **No resource replacements; any replacement is a bug — please open an issue.**
+
+### OIDC provider: `thumbprint_list` drops out of Terraform management
+
+```
+  ~ resource "aws_iam_openid_connect_provider" "github" {
+      ~ thumbprint_list = [
+          - "6938fd4d98bab03faadb97b34396831e3780aea1",
+        ]
+        # (other attributes unchanged)
+    }
+```
+
+AWS-specific behavior to be aware of: when Terraform stops managing `thumbprint_list`, IAM does **not** re-auto-retrieve a thumbprint — the value you set previously persists on the AWS side. For the GitHub issuer this is irrelevant: AWS ignores configured thumbprints for `token.actions.githubusercontent.com` and validates against its own trusted root CA library regardless. No action needed.
+
+### IAM roles: `managed_policy_arns` → separate `aws_iam_role_policy_attachment` resources
+
+v1.0.0 swaps the deprecated `managed_policy_arns` attribute on `aws_iam_role` for standalone `aws_iam_role_policy_attachment` resources (one per policy ARN, managed via `for_each`).
+
+```
+  ~ resource "aws_iam_role" "github_ci" {
+      ~ managed_policy_arns = [
+          - "arn:aws:iam::aws:policy/AmazonS3ReadOnlyAccess",
+        ] -> (known after apply)
+        # (other attributes unchanged)
+    }
+
+  + resource "aws_iam_role_policy_attachment" "github_ci" {
+      + policy_arn = "arn:aws:iam::aws:policy/AmazonS3ReadOnlyAccess"
+      + role       = "deploy-main"
+    }
+```
+
+**No live privilege gap.** AWS evaluates the new `aws_iam_role_policy_attachment` before detaching the old `managed_policy_arns` entries, all in the same apply. A workflow that runs mid-apply keeps the policies it had going in.
+
+Terraform `moved` blocks can't migrate an attribute on one resource type to an entirely different resource type, so this is a detach/reattach rather than a state rename. The role itself is **not** replaced.
+
+### Roles appear unchanged
+
+The IAM role resources themselves (`aws_iam_role.github_ci`) should show no diff other than the `managed_policy_arns` drop above. Role ARNs, IDs, and trust policies are untouched.
+
+## Staying on v0.x
+
+Not ready to migrate? Pin to v0.6.x:
+
+```hcl
+module "aws_oidc_github" {
+  source  = "pelotech/oidc-github/aws"
+  version = "~> 0.6"
+  # …
+}
+```
+
+v0.6.x will continue to work but won't receive further development. Plan your migration on a calendar that suits you.
+
+## Questions / issues
+
+Open an issue at <https://github.com/pelotech/terraform-aws-oidc-github/issues> with the relevant `terraform plan` output.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Provision GitHub Actions → AWS authentication via OpenID Connect, with no long-lived AWS keys.
 
-This module creates the GitHub OIDC identity provider in your AWS account and one IAM role per entry in `role_subject-repos_policies`. Each role trusts a configurable set of GitHub subject claims (specific repos, branches, tags, environments, or pull requests) and attaches the IAM policies you specify. Based on the [official GitHub OIDC for AWS guide](https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/configuring-openid-connect-in-amazon-web-services).
+This module creates the GitHub OIDC identity provider in your AWS account and one IAM role per entry in `roles`. Each role trusts a configurable set of GitHub subject claims (specific repos, branches, tags, environments, or pull requests) and attaches the IAM policies you specify. Based on the [official GitHub OIDC for AWS guide](https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/configuring-openid-connect-in-amazon-web-services).
 
 ## How it fits together
 
@@ -26,7 +26,7 @@ The trust policy on each role pins the GitHub `sub` claim to the patterns in `su
 module "aws_oidc_github" {
   source  = "pelotech/oidc-github/aws"
 
-  role_subject-repos_policies = {
+  roles = {
     "deploy-main" = {
       subject_repos = ["repo:my-org/my-repo:ref:refs/heads/main"]
       policy_arns   = ["arn:aws:iam::aws:policy/AmazonS3ReadOnlyAccess"]
@@ -49,7 +49,7 @@ A multi-role example with comments lives in [`examples/`](./examples). Highlight
 module "aws_oidc_github" {
   source = "pelotech/oidc-github/aws"
 
-  role_subject-repos_policies = {
+  roles = {
     # Production deploys: only `main`, with full access and an SSO debug escape hatch.
     "infra-prod" = {
       role_path         = "/github/"
@@ -103,11 +103,11 @@ jobs:
       - run: aws sts get-caller-identity
 ```
 
-The `role-to-assume` value is the full ARN of one of the roles this module created — `module.aws_oidc_github.iam_role_arns_map[<role-name>]` (the map key matches the entry name you used in `role_subject-repos_policies`). The older `iam_role_arns` flat-list output is deprecated and will be removed in v2.
+The `role-to-assume` value is the full ARN of one of the roles this module created — `module.aws_oidc_github.iam_role_arns_map[<role-name>]` (the map key matches the entry name you used in `roles`).
 
 ## Debugging with `assume_role_names`
 
-Each entry in `role_subject-repos_policies` accepts an `assume_role_names` list. Any IAM role in the same AWS account named in that list is also allowed to assume the OIDC role via plain `sts:AssumeRole` — useful while you're iterating, because you can run `aws sts assume-role --role-arn ...` from your laptop and act as the workflow.
+Each entry in `roles` accepts an `assume_role_names` list. Any IAM role in the same AWS account named in that list is also allowed to assume the OIDC role via plain `sts:AssumeRole` — useful while you're iterating, because you can run `aws sts assume-role --role-arn ...` from your laptop and act as the workflow.
 
 > Remove `assume_role_names` (or set it to `[]`) before going to production. Once the workflow is stable, the only path to the role should be the OIDC trust.
 
@@ -144,13 +144,13 @@ The [`wrappers/`](./wrappers) directory contains thin wrapper modules pre-config
 | Name | Version |
 | ---- | ------- |
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5.7 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.39.0 |
 
 ## Providers
 
 | Name | Version |
 | ---- | ------- |
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.39.0 |
 
 ## Modules
 
@@ -171,7 +171,7 @@ The [`wrappers/`](./wrappers) directory contains thin wrapper modules pre-config
 | <a name="input_aud_value"></a> [aud\_value](#input\_aud\_value) | Audience claim required in the OIDC token. Defaults to the value the official aws-actions/configure-aws-credentials action sends. | `string` | `"sts.amazonaws.com"` | no |
 | <a name="input_github_tls_url"></a> [github\_tls\_url](#input\_github\_tls\_url) | GitHub OIDC issuer URL. Override only for GitHub Enterprise Server. | `string` | `"https://token.actions.githubusercontent.com"` | no |
 | <a name="input_max_session_duration"></a> [max\_session\_duration](#input\_max\_session\_duration) | Maximum session duration in seconds for every role created. Defaults to 1 hour. Increase up to 43200 (12h) if your workflows need longer sessions. | `number` | `3600` | no |
-| <a name="input_role_subject-repos_policies"></a> [role\_subject-repos\_policies](#input\_role\_subject-repos\_policies) | Map of IAM roles to create. The map key is the role name. Each value defines:<br/>  - `subject_repos`     : OIDC subject claims allowed to assume this role (e.g. "repo:my-org/my-repo:ref:refs/heads/main").<br/>  - `policy_arns`       : IAM policy ARNs to attach to the role.<br/>  - `role_path`         : (optional) IAM path for the role. Defaults to "/".<br/>  - `assume_role_names` : (optional) IAM role names in the same account that may also assume this role (useful for local debugging). | <pre>map(object({<br/>    role_path         = optional(string, "/")<br/>    subject_repos     = list(string)<br/>    policy_arns       = list(string)<br/>    assume_role_names = optional(list(string))<br/>  }))</pre> | n/a | yes |
+| <a name="input_roles"></a> [roles](#input\_roles) | Map of IAM roles to create. The map key is the role name. Each value defines:<br/>  - `subject_repos`     : OIDC subject claims allowed to assume this role (e.g. "repo:my-org/my-repo:ref:refs/heads/main").<br/>  - `policy_arns`       : IAM policy ARNs to attach to the role.<br/>  - `role_path`         : (optional) IAM path for the role. Defaults to "/".<br/>  - `assume_role_names` : (optional) IAM role names in the same account that may also assume this role (useful for local debugging). | <pre>map(object({<br/>    role_path         = optional(string, "/")<br/>    subject_repos     = list(string)<br/>    policy_arns       = list(string)<br/>    assume_role_names = optional(list(string))<br/>  }))</pre> | n/a | yes |
 | <a name="input_tags"></a> [tags](#input\_tags) | Tags applied to the OIDC provider and every IAM role created by this module. | `map(string)` | `{}` | no |
 
 ## Outputs
@@ -180,6 +180,5 @@ The [`wrappers/`](./wrappers) directory contains thin wrapper modules pre-config
 | ---- | ----------- |
 | <a name="output_github_oidc_provider_arn"></a> [github\_oidc\_provider\_arn](#output\_github\_oidc\_provider\_arn) | oidc provider arn to use for roles/policies |
 | <a name="output_github_oidc_provider_url"></a> [github\_oidc\_provider\_url](#output\_github\_oidc\_provider\_url) | oidc provider url to use for roles/policies |
-| <a name="output_iam_role_arns"></a> [iam\_role\_arns](#output\_iam\_role\_arns) | Roles that will be assumed by GitHub Action. (Deprecated: use `iam_role_arns_map` instead; this output will be removed in v2.) |
-| <a name="output_iam_role_arns_map"></a> [iam\_role\_arns\_map](#output\_iam\_role\_arns\_map) | Map of role name to role ARN. Prefer this output; the flat `iam_role_arns` list will be removed in v2. |
+| <a name="output_iam_role_arns_map"></a> [iam\_role\_arns\_map](#output\_iam\_role\_arns\_map) | Map of role name to IAM role ARN. |
 <!-- END_TF_DOCS -->

--- a/examples/main.tf
+++ b/examples/main.tf
@@ -3,11 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.0"
-    }
-    tls = {
-      source  = "hashicorp/tls"
-      version = ">= 4.0.3"
+      version = ">= 5.39.0"
     }
   }
 }
@@ -23,7 +19,7 @@ module "aws_oidc_github" {
     aws = aws.my_alias
   }
 
-  role_subject-repos_policies = {
+  roles = {
     # A role scoped to the `main` branch of one repo, granted Administrator,
     # and additionally assumable by an SSO role for local debugging.
     "org-infra-main" = {

--- a/main.tf
+++ b/main.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.0"
+      version = ">= 5.39.0"
     }
   }
 }
@@ -11,16 +11,11 @@ terraform {
 resource "aws_iam_openid_connect_provider" "github" {
   url            = var.github_tls_url
   client_id_list = [var.aud_value]
-  # AWS stopped enforcing thumbprint verification for the GitHub OIDC issuer in
-  # mid-2023, but the AWS provider still requires a 40-char hex value. Pass the
-  # historical GitHub thumbprint as a placeholder; the actual trust is enforced
-  # by IAM via the provider URL, not this value.
-  thumbprint_list = ["6938fd4d98bab03faadb97b34396831e3780aea1"]
-  tags            = var.tags
+  tags           = var.tags
 }
 
 module "aws_oidc_github" {
-  for_each                 = var.role_subject-repos_policies
+  for_each                 = var.roles
   source                   = "./modules/aws-roles-oidc-github"
   role_name                = each.key
   role_path                = each.value.role_path

--- a/modules/aws-roles-oidc-github/README.md
+++ b/modules/aws-roles-oidc-github/README.md
@@ -1,6 +1,6 @@
 # aws-roles-oidc-github (internal submodule)
 
-This is an **internal building block** consumed by the root [`terraform-aws-oidc-github`](../../README.md) module. Most users should consume the root module directly — it provisions the OIDC provider and calls this submodule once per role you define in `role_subject-repos_policies`.
+This is an **internal building block** consumed by the root [`terraform-aws-oidc-github`](../../README.md) module. Most users should consume the root module directly — it provisions the OIDC provider and calls this submodule once per role you define in `roles`.
 
 Use this submodule directly **only** if you already manage your `aws_iam_openid_connect_provider` elsewhere and want to layer additional roles onto it without re-creating the provider. In that case, pass the existing provider's ARN and URL into `github_oidc_provider_arn` and `github_oidc_provider_url`.
 
@@ -10,13 +10,13 @@ Use this submodule directly **only** if you already manage your `aws_iam_openid_
 | Name | Version |
 | ---- | ------- |
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5.7 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.39.0 |
 
 ## Providers
 
 | Name | Version |
 | ---- | ------- |
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.39.0 |
 
 ## Modules
 
@@ -27,6 +27,7 @@ No modules.
 | Name | Type |
 | ---- | ---- |
 | [aws_iam_role.github_ci](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
+| [aws_iam_role_policy_attachment.github_ci](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
 | [aws_iam_policy_document.assume_role_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_partition.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/partition) | data source |

--- a/modules/aws-roles-oidc-github/main.tf
+++ b/modules/aws-roles-oidc-github/main.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.0"
+      version = ">= 5.39.0"
     }
   }
 }
@@ -51,6 +51,11 @@ resource "aws_iam_role" "github_ci" {
   description          = "GitHubCI with OIDC"
   max_session_duration = var.max_session_duration
   assume_role_policy   = data.aws_iam_policy_document.assume_role_policy.json
-  managed_policy_arns  = var.policy_arns
   tags                 = var.tags
+}
+
+resource "aws_iam_role_policy_attachment" "github_ci" {
+  for_each   = toset(var.policy_arns)
+  role       = aws_iam_role.github_ci.name
+  policy_arn = each.value
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,10 +1,5 @@
-output "iam_role_arns" {
-  description = "Roles that will be assumed by GitHub Action. (Deprecated: use `iam_role_arns_map` instead; this output will be removed in v2.)"
-  value       = values(module.aws_oidc_github)[*].iam_role_arn
-}
-
 output "iam_role_arns_map" {
-  description = "Map of role name to role ARN. Prefer this output; the flat `iam_role_arns` list will be removed in v2."
+  description = "Map of role name to IAM role ARN."
   value       = { for k, m in module.aws_oidc_github : k => m.iam_role_arn }
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -1,4 +1,4 @@
-variable "role_subject-repos_policies" {
+variable "roles" {
   type = map(object({
     role_path         = optional(string, "/")
     subject_repos     = list(string)
@@ -15,14 +15,14 @@ variable "role_subject-repos_policies" {
 
   validation {
     condition = alltrue([
-      for v in var.role_subject-repos_policies : alltrue([for r in v.subject_repos : startswith(r, "repo:")])
+      for v in var.roles : alltrue([for r in v.subject_repos : startswith(r, "repo:")])
     ])
     error_message = "Every subject_repos entry must start with \"repo:\" (e.g. \"repo:my-org/my-repo:ref:refs/heads/main\")."
   }
 
   validation {
     condition = alltrue([
-      for v in var.role_subject-repos_policies : can(regex("^/([a-zA-Z0-9._+-]+/)*$", v.role_path))
+      for v in var.roles : can(regex("^/([a-zA-Z0-9._+-]+/)*$", v.role_path))
     ])
     error_message = "Each role_path must start and end with '/' and only contain [a-zA-Z0-9._+-] segments (e.g. \"/\", \"/github/\", \"/teams/platform/\")."
   }


### PR DESCRIPTION
## Summary

The breaking v2 cutover for `terraform-aws-oidc-github`, completing the staged roadmap (see `docs/superpowers/specs/2026-04-23-staged-v2-roadmap-design.md`). Stage 1 landed as v0.6.0 (additive-only). This Stage 2 PR will cut **v1.0.0** via release-please (`feat!:` → first breaking release from 0.x).

- Rename input `role_subject-repos_policies` → `roles` (and drop the tflint variable-naming exception it required).
- Remove deprecated `iam_role_arns` list output. Use `iam_role_arns_map["<name>"]` — which has been available and documented since v0.6.0.
- Delete `thumbprint_list` from the OIDC provider. AWS provider v5.39.0 made the field optional, and AWS ignores configured thumbprints for the GitHub issuer regardless (validates against its own trusted CA library).
- Replace the deprecated `aws_iam_role.managed_policy_arns` attribute with separate `aws_iam_role_policy_attachment` resources (`for_each` over `toset(var.policy_arns)`).
- Bump `hashicorp/aws` floor from `>= 4.0` to `>= 5.39.0` (root, submodule, examples).
- Clean stale `tls` provider from `examples/main.tf` required_providers (leftover from pre-Stage-1).
- Ship `MIGRATING.md` at repo root covering renames, `terraform plan` expectations, and version floors.

**No resource replacements** against a v0.6.x deployment: OIDC provider is updated in place (thumbprint drops out of TF management, AWS-stored value persists harmlessly); IAM roles keep their ARNs (just lose `managed_policy_arns`); `aws_iam_role_policy_attachment` resources are net-new but AWS evaluates them before detaching the old ones in the same apply, so no live privilege gap.

## Test Plan

- [x] `pre-commit run --all-files` — all hooks pass (fmt, yamllint, tflint with default snake_case).
- [x] `terraform init && terraform validate` — passes at repo root.
- [ ] Against a throwaway v0.6.x-deployed AWS account: `terraform plan` shows only in-place updates (thumbprint drop + policy detach/reattach + net-new `aws_iam_role_policy_attachment`); **no resource replacements**.
- [ ] `terraform plan` with an old `role_subject-repos_policies = { … }` call fails fast with "unknown argument".
- [ ] Walk through `MIGRATING.md` top-to-bottom on a scratch project cloned from a v0.6.x deployment.
- [ ] Confirm release-please's release PR targets v1.0.0 (not v0.7.0) from the `feat!:` footer.

## Notes

- `examples/` `terraform validate` will fail against the registry until v1.0.0 publishes (the example's `source = "pelotech/oidc-github/aws"` resolves to v0.6.x which still uses the old variable name). Expected; resolves after tag/release.
- `wrappers/` is gitignored in this repo, so local edits there are not included.