### PR TITLE
docs: remove wrappers/ reference from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,10 +128,6 @@ The role lives in the account where you applied this module. The `role-to-assume
 **Custom audience**
 If you set `audience:` on `aws-actions/configure-aws-credentials`, set the matching `aud_value` here. The default (`sts.amazonaws.com`) matches the action's default.
 
-## Wrappers
-
-The [`wrappers/`](./wrappers) directory contains thin wrapper modules pre-configured to call this module. They're useful if you'd rather declare your roles in `terraform.tfvars`-friendly shapes than write a `module` block. Most users won't need them.
-
 ## Contributing & releases
 
 - This repo uses [Conventional Commits](https://www.conventionalcommits.org/) and `release-please` to drive versioning. Use `feat:`, `fix:`, `chore:`, etc. so the changelog and version bumps are correct.


### PR DESCRIPTION
## Summary

- Removes the "## Wrappers" section from `README.md`.
- `wrappers/` is generated locally by the `terraform_wrapper_module_for_each` pre-commit hook (see `.pre-commit-config.yaml`) and is gitignored — it has never been part of the published module, so the README section was pointing at files consumers can't actually get.
- `.gitignore` entry is left in place; the hook keeps regenerating `wrappers/` locally for anyone who wants to use it out-of-tree, and nothing else changes.

If a user requests the wrapper pattern later we can commit the generated output and reintroduce the doc section in one go.

## Test Plan

- [x] `pre-commit run --all-files` passes.
- [x] No other README/docs reference `wrappers/` (`grep -ri wrapper` on tracked files returns only this commit's deletion).