### PR TITLE
docs: security notes + repo hygiene (badge, CODEOWNERS, issue template)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @pelotech/developers

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,46 @@
+---
+name: Bug report
+about: Something not working as expected
+title: ""
+labels: bug
+assignees: ""
+---
+
+## What happened
+
+<!-- 1–2 sentences. What did you expect, what did you see instead? -->
+
+## Module / provider versions
+
+- Module version: (e.g. `v1.0.0`)
+- Terraform: (output of `terraform version`)
+- aws provider: (from `.terraform.lock.hcl`)
+
+## Relevant configuration
+
+<details><summary>module block</summary>
+
+```hcl
+# paste the module "aws_oidc_github" { … } block here
+```
+
+</details>
+
+## `terraform plan` / `apply` output
+
+<details><summary>output</summary>
+
+```
+# redact account IDs / role ARNs as needed
+```
+
+</details>
+
+## For OIDC assume-role failures only
+
+If the workflow hits "Not authorized to perform sts:AssumeRoleWithWebIdentity", please include:
+
+- The `Configure AWS Credentials` step output with `debug: true`, **or**
+- The `sub` claim value GitHub sent (visible in the step log when debug is on).
+
+This is almost always a subject-claim mismatch and the diff is obvious once both strings are side by side.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # terraform-aws-oidc-github
 
+[![Latest Release](https://img.shields.io/github/v/release/pelotech/terraform-aws-oidc-github?sort=semver&display_name=release)](https://github.com/pelotech/terraform-aws-oidc-github/releases)
+
 Provision GitHub Actions → AWS authentication via OpenID Connect, with no long-lived AWS keys.
 
 This module creates the GitHub OIDC identity provider in your AWS account and one IAM role per entry in `roles`. Each role trusts a configurable set of GitHub subject claims (specific repos, branches, tags, environments, or pull requests) and attaches the IAM policies you specify. Based on the [official GitHub OIDC for AWS guide](https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/configuring-openid-connect-in-amazon-web-services).
@@ -83,6 +85,14 @@ The `subject_repos` list contains GitHub OIDC `sub` claim patterns. Common shape
 GitHub's full claim reference: <https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/about-security-hardening-with-openid-connect#example-subject-claims>.
 
 > **Tip:** Prefer GitHub Environments over branch matching when you can — environments give you reviewer gates, secrets scoping, and protection rules on the GitHub side.
+
+## Security notes
+
+A few patterns that are easy to reach for and cause real damage:
+
+- **Avoid `repo:ORG/*` on high-privilege roles.** A wildcard `sub` claim lets any repo in the org (including a private fork created by a compromised contributor) assume the role. Prefer specific repo + branch, or — better — a `repo:ORG/REPO:environment:production` claim gated by a GitHub Environment with reviewer approval.
+- **Treat `assume_role_names` as a development-only escape hatch.** Never point it at a broad SSO role such as `AWSReservedSSO_AdministratorAccess_*`; that lets anyone with console access impersonate the CI role. Use a named, least-privilege debug role, and remove the entry before production.
+- **Keep `max_session_duration` tight.** Start at the default (1 hour). Only raise it for workflows that demonstrably need longer sessions — AWS allows up to 12 hours, but a leaked OIDC token is valid for the full duration.
 
 ## GitHub Actions workflow
 


### PR DESCRIPTION
## Summary

Two low-risk, no-code changes batched into one PR. Neither triggers a release (release-please treats `docs:` and `chore:` as no-bump).

- **README**: adds a GitHub release badge below the H1 and a new **Security notes** section calling out the three highest-impact footguns — overly broad `repo:ORG/*` subject claims, misusing `assume_role_names` for SSO impersonation, and extending `max_session_duration` past defaults without a specific need.
- **`.github/CODEOWNERS`**: single-line file pointing `*` at `@pelotech/developers` so every PR auto-requests a team review. Team verified via `gh api repos/pelotech/terraform-aws-oidc-github/teams`.
- **`.github/ISSUE_TEMPLATE/bug_report.md`**: markdown template front-loading the artifacts every OIDC issue needs (module/provider versions, module block, plan/apply output, and the `sub`-claim detail that resolves \~all \"Not authorized to perform sts:AssumeRoleWithWebIdentity\" reports).

No Terraform code touched. No consumer breakage possible.

## Test plan

- [ ] Release badge renders correctly on GitHub for the branch
- [ ] This PR auto-requests review from `@pelotech/developers` (validates CODEOWNERS path)
- [ ] Bug-report template previews cleanly in the GitHub issue UI on this branch
- [x] `pre-commit run --all-files` passes locally