### PR TITLE
feat: v1.1 validations and iam_role_names output

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,4 +187,5 @@ If you set `audience:` on `aws-actions/configure-aws-credentials`, set the match
 | <a name="output_github_oidc_provider_arn"></a> [github\_oidc\_provider\_arn](#output\_github\_oidc\_provider\_arn) | oidc provider arn to use for roles/policies |
 | <a name="output_github_oidc_provider_url"></a> [github\_oidc\_provider\_url](#output\_github\_oidc\_provider\_url) | oidc provider url to use for roles/policies |
 | <a name="output_iam_role_arns_map"></a> [iam\_role\_arns\_map](#output\_iam\_role\_arns\_map) | Map of role name to IAM role ARN. |
+| <a name="output_iam_role_names"></a> [iam\_role\_names](#output\_iam\_role\_names) | Map of role name (the var.roles key) to the created IAM role name. Useful for wiring downstream resources (e.g. aws\_iam\_role\_policy) without parsing the ARN. |
 <!-- END_TF_DOCS -->

--- a/modules/aws-roles-oidc-github/outputs.tf
+++ b/modules/aws-roles-oidc-github/outputs.tf
@@ -2,3 +2,8 @@ output "iam_role_arn" {
   description = "Role that will be assumed by GitHub Action"
   value       = aws_iam_role.github_ci.arn
 }
+
+output "iam_role_name" {
+  description = "Name of the IAM role created for this GitHub Actions entry."
+  value       = aws_iam_role.github_ci.name
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -3,6 +3,11 @@ output "iam_role_arns_map" {
   value       = { for k, m in module.aws_oidc_github : k => m.iam_role_arn }
 }
 
+output "iam_role_names" {
+  description = "Map of role name (the var.roles key) to the created IAM role name. Useful for wiring downstream resources (e.g. aws_iam_role_policy) without parsing the ARN."
+  value       = { for k, m in module.aws_oidc_github : k => m.iam_role_name }
+}
+
 output "github_oidc_provider_arn" {
   description = "oidc provider arn to use for roles/policies"
   value       = aws_iam_openid_connect_provider.github.arn

--- a/variables.tf
+++ b/variables.tf
@@ -26,6 +26,22 @@ variable "roles" {
     ])
     error_message = "Each role_path must start and end with '/' and only contain [a-zA-Z0-9._+-] segments (e.g. \"/\", \"/github/\", \"/teams/platform/\")."
   }
+
+  validation {
+    condition = alltrue([
+      for name, _ in var.roles : can(regex("^[a-zA-Z0-9+=,.@_-]{1,64}$", name))
+    ])
+    error_message = "Each role name (the map key in var.roles) must be 1–64 characters and match the IAM-allowed charset [a-zA-Z0-9+=,.@_-]."
+  }
+
+  validation {
+    condition = alltrue([
+      for v in var.roles : alltrue([
+        for arn in v.policy_arns : can(regex("^arn:aws[a-z0-9-]*:iam::(aws|[0-9]{12}):policy/", arn))
+      ])
+    ])
+    error_message = "Every policy_arns entry must be a valid IAM policy ARN (e.g. \"arn:aws:iam::aws:policy/ReadOnlyAccess\" or \"arn:aws:iam::123456789012:policy/my-policy\")."
+  }
 }
 
 variable "tags" {


### PR DESCRIPTION
## Summary

Option A from the post-v1 usability review: three small, additive improvements bundled as one `feat:` PR so release-please cuts a single `v1.1.0`. All backwards compatible.

### 1. `policy_arns` ARN-format validation

Validates each entry matches an IAM policy ARN shape (`arn:aws[partition]:iam::(aws|<12 digits>):policy/...`). Catches typos like `arn:aws:s3:::my-bucket` or `arn:aws:iam::aws:role/Admin` at plan time with a clear message, instead of surfacing later as an opaque AWS API error on apply. Supports `aws`, `aws-cn`, and `aws-us-gov` partitions.

### 2. Role name charset/length validation

The map key in `var.roles` becomes the IAM role name. AWS rejects anything outside `[a-zA-Z0-9+=,.@_-]{1,64}` but only at apply time. This validation moves that failure to plan time.

### 3. `iam_role_names` output

New map output: role key → created IAM role name. Pairs with the existing `iam_role_arns_map` and removes the need for consumers to parse ARNs when wiring downstream resources like `aws_iam_role_policy`.

## Compatibility

- **No breaking changes.** Every previously-valid configuration still passes.
- **No input changes.** Only new validations and one new output.
- Release-please will pick this up as a minor bump (`v1.0.0` → `v1.1.0`).

## Test plan

- [x] `terraform validate` passes on root and submodule
- [x] `pre-commit run --all-files` passes (fmt, tflint, yamllint, wrapper regen)
- [x] README tf-docs regenerated (new `iam_role_names` output listed)
- [ ] Manually confirm a bad policy ARN fails validation with the intended message
- [ ] Manually confirm an invalid role name (e.g. containing a space) fails with the intended message