### PR TITLE
feat: per-role max_session_duration and inline policy support

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,9 +65,30 @@ module "aws_oidc_github" {
       subject_repos = ["repo:my-org/infrastructure:pull_request"]
       policy_arns   = ["arn:aws:iam::aws:policy/ReadOnlyAccess"]
     }
+
+    # Long integration job: bump the session to 4h and add a bespoke inline policy
+    # for a grant that's too narrow to justify a standalone aws_iam_policy.
+    "infra-integration-tests" = {
+      subject_repos        = ["repo:my-org/infrastructure:environment:integration"]
+      policy_arns          = ["arn:aws:iam::aws:policy/ReadOnlyAccess"]
+      max_session_duration = 14400 # 4h, overrides the module-level default
+
+      inline_policies = {
+        "describe-integration-stacks" = data.aws_iam_policy_document.describe_integration_stacks.json
+      }
+    }
   }
 }
 ```
+
+Each entry in `roles` supports the following keys:
+
+- `subject_repos` (required) — OIDC subject claims allowed to assume the role. See the cheat sheet below.
+- `policy_arns` (required, may be empty) — IAM policy ARNs to attach.
+- `inline_policies` (optional) — Map of policy name → rendered policy document JSON. Good for one-off grants that don't deserve a standalone `aws_iam_policy`.
+- `max_session_duration` (optional) — Per-role override in seconds (3600–43200). Omit to inherit the module-level `var.max_session_duration`.
+- `role_path` (optional) — IAM path. Defaults to `/`.
+- `assume_role_names` (optional) — IAM role names in the same account that may also `sts:AssumeRole` this role. Development-only escape hatch; see [Security notes](#security-notes).
 
 ## Subject string cheat sheet
 
@@ -177,7 +198,7 @@ If you set `audience:` on `aws-actions/configure-aws-credentials`, set the match
 | <a name="input_aud_value"></a> [aud\_value](#input\_aud\_value) | Audience claim required in the OIDC token. Defaults to the value the official aws-actions/configure-aws-credentials action sends. | `string` | `"sts.amazonaws.com"` | no |
 | <a name="input_github_tls_url"></a> [github\_tls\_url](#input\_github\_tls\_url) | GitHub OIDC issuer URL. Override only for GitHub Enterprise Server. | `string` | `"https://token.actions.githubusercontent.com"` | no |
 | <a name="input_max_session_duration"></a> [max\_session\_duration](#input\_max\_session\_duration) | Maximum session duration in seconds for every role created. Defaults to 1 hour. Increase up to 43200 (12h) if your workflows need longer sessions. | `number` | `3600` | no |
-| <a name="input_roles"></a> [roles](#input\_roles) | Map of IAM roles to create. The map key is the role name. Each value defines:<br/>  - `subject_repos`     : OIDC subject claims allowed to assume this role (e.g. "repo:my-org/my-repo:ref:refs/heads/main").<br/>  - `policy_arns`       : IAM policy ARNs to attach to the role.<br/>  - `role_path`         : (optional) IAM path for the role. Defaults to "/".<br/>  - `assume_role_names` : (optional) IAM role names in the same account that may also assume this role (useful for local debugging). | <pre>map(object({<br/>    role_path         = optional(string, "/")<br/>    subject_repos     = list(string)<br/>    policy_arns       = list(string)<br/>    assume_role_names = optional(list(string))<br/>  }))</pre> | n/a | yes |
+| <a name="input_roles"></a> [roles](#input\_roles) | Map of IAM roles to create. The map key is the role name. Each value defines:<br/>  - `subject_repos`        : OIDC subject claims allowed to assume this role (e.g. "repo:my-org/my-repo:ref:refs/heads/main").<br/>  - `policy_arns`          : IAM policy ARNs to attach to the role.<br/>  - `role_path`            : (optional) IAM path for the role. Defaults to "/".<br/>  - `assume_role_names`    : (optional) IAM role names in the same account that may also assume this role (useful for local debugging).<br/>  - `max_session_duration` : (optional) Per-role override of the module-level max\_session\_duration, in seconds. Must be 3600-43200. Omit to inherit var.max\_session\_duration.<br/>  - `inline_policies`      : (optional) Map of inline IAM policy name to rendered policy document JSON (typically from data.aws\_iam\_policy\_document.<name>.json). | <pre>map(object({<br/>    role_path            = optional(string, "/")<br/>    subject_repos        = list(string)<br/>    policy_arns          = list(string)<br/>    assume_role_names    = optional(list(string))<br/>    max_session_duration = optional(number)<br/>    inline_policies      = optional(map(string), {})<br/>  }))</pre> | n/a | yes |
 | <a name="input_tags"></a> [tags](#input\_tags) | Tags applied to the OIDC provider and every IAM role created by this module. | `map(string)` | `{}` | no |
 
 ## Outputs

--- a/main.tf
+++ b/main.tf
@@ -24,6 +24,7 @@ module "aws_oidc_github" {
   assume_role_names        = each.value.assume_role_names
   github_oidc_provider_arn = aws_iam_openid_connect_provider.github.arn
   github_oidc_provider_url = aws_iam_openid_connect_provider.github.url
-  max_session_duration     = var.max_session_duration
+  max_session_duration     = coalesce(each.value.max_session_duration, var.max_session_duration)
+  inline_policies          = each.value.inline_policies
   tags                     = var.tags
 }

--- a/modules/aws-roles-oidc-github/main.tf
+++ b/modules/aws-roles-oidc-github/main.tf
@@ -59,3 +59,11 @@ resource "aws_iam_role_policy_attachment" "github_ci" {
   role       = aws_iam_role.github_ci.name
   policy_arn = each.value
 }
+
+resource "aws_iam_role_policy" "inline" {
+  for_each = var.inline_policies
+
+  name   = each.key
+  role   = aws_iam_role.github_ci.name
+  policy = each.value
+}

--- a/modules/aws-roles-oidc-github/variables.tf
+++ b/modules/aws-roles-oidc-github/variables.tf
@@ -33,6 +33,12 @@ variable "policy_arns" {
   description = "IAM policy ARNs to attach to the role (managed or customer-managed policies)."
 }
 
+variable "inline_policies" {
+  type        = map(string)
+  default     = {}
+  description = "Inline IAM policies to attach to the role. Map of policy name to rendered policy document JSON (typically from data.aws_iam_policy_document.<name>.json)."
+}
+
 variable "assume_role_names" {
   type        = list(string)
   default     = []

--- a/variables.tf
+++ b/variables.tf
@@ -1,16 +1,20 @@
 variable "roles" {
   type = map(object({
-    role_path         = optional(string, "/")
-    subject_repos     = list(string)
-    policy_arns       = list(string)
-    assume_role_names = optional(list(string))
+    role_path            = optional(string, "/")
+    subject_repos        = list(string)
+    policy_arns          = list(string)
+    assume_role_names    = optional(list(string))
+    max_session_duration = optional(number)
+    inline_policies      = optional(map(string), {})
   }))
   description = <<-EOT
     Map of IAM roles to create. The map key is the role name. Each value defines:
-      - `subject_repos`     : OIDC subject claims allowed to assume this role (e.g. "repo:my-org/my-repo:ref:refs/heads/main").
-      - `policy_arns`       : IAM policy ARNs to attach to the role.
-      - `role_path`         : (optional) IAM path for the role. Defaults to "/".
-      - `assume_role_names` : (optional) IAM role names in the same account that may also assume this role (useful for local debugging).
+      - `subject_repos`        : OIDC subject claims allowed to assume this role (e.g. "repo:my-org/my-repo:ref:refs/heads/main").
+      - `policy_arns`          : IAM policy ARNs to attach to the role.
+      - `role_path`            : (optional) IAM path for the role. Defaults to "/".
+      - `assume_role_names`    : (optional) IAM role names in the same account that may also assume this role (useful for local debugging).
+      - `max_session_duration` : (optional) Per-role override of the module-level max_session_duration, in seconds. Must be 3600-43200. Omit to inherit var.max_session_duration.
+      - `inline_policies`      : (optional) Map of inline IAM policy name to rendered policy document JSON (typically from data.aws_iam_policy_document.<name>.json).
   EOT
 
   validation {
@@ -41,6 +45,23 @@ variable "roles" {
       ])
     ])
     error_message = "Every policy_arns entry must be a valid IAM policy ARN (e.g. \"arn:aws:iam::aws:policy/ReadOnlyAccess\" or \"arn:aws:iam::123456789012:policy/my-policy\")."
+  }
+
+  validation {
+    condition = alltrue([
+      for v in var.roles :
+      try(v.max_session_duration >= 3600 && v.max_session_duration <= 43200, true)
+    ])
+    error_message = "Per-role max_session_duration must be null (to inherit the module default) or between 3600 (1h) and 43200 (12h) — AWS-enforced bounds."
+  }
+
+  validation {
+    condition = alltrue([
+      for v in var.roles : alltrue([
+        for name, _ in v.inline_policies : can(regex("^[a-zA-Z0-9+=,.@_-]{1,128}$", name))
+      ])
+    ])
+    error_message = "Each inline_policies map key (the IAM policy name) must be 1–128 characters and match [a-zA-Z0-9+=,.@_-]."
   }
 }
 


### PR DESCRIPTION
## Summary

Bundles the two remaining small-effort items from the post-v1 usability review into one `feat:` PR. Both are pure additions to the `var.roles` object schema — fully backwards compatible, existing plans emit zero diff on upgrade. Release-please will cut **v1.2.0**.

### Per-role `max_session_duration`

Optional field on each role entry; falls back to `var.max_session_duration` when omitted. Same 3600–43200 validation as the module-level variable, applied per-role.

Motivation: CI jobs mix short and long workloads in the same account. Forcing one duration across every role either leaks long sessions everywhere or blocks jobs that need 4–6h.

### `inline_policies`

Optional `map(string)` on each role entry, rendered as `aws_iam_role_policy` resources in the submodule. Keys become IAM policy names; values are rendered policy JSON (typically from `data.aws_iam_policy_document`).

Motivation: callers who need a bespoke grant for one role currently have to create a standalone `aws_iam_policy` and thread its ARN through `policy_arns`. Inline policies are the lower-ceremony path Terraform already provides.

## Compatibility

- `max_session_duration` is `optional(number)` with no default → `null` when omitted → `coalesce` in the root module falls back to `var.max_session_duration`. Zero-diff upgrade.
- `inline_policies` is `optional(map(string), {})` → empty map when omitted → `for_each` over an empty map creates zero resources. Zero-diff upgrade.

## Test plan

- [x] `terraform validate` passes
- [x] `pre-commit run --all-files` passes (fmt, tflint, yamllint, wrapper regen)
- [x] Validation smoke test: a role with `max_session_duration = 1800` is rejected at plan time with the band error message
- [x] Validation smoke test: a role with `inline_policies = { "bad name" = "{}" }` is rejected at plan time with the name-charset error message
- [x] Happy path: `var.roles["long"].max_session_duration` evaluates to the override value in `terraform console`
- [x] README tf-docs regenerated; Full example extended with a role exercising both fields